### PR TITLE
feat: improve VenomScan UX with severity scoring and --no-nmap

### DIFF
--- a/venomscan/severity.py
+++ b/venomscan/severity.py
@@ -50,7 +50,7 @@ def severity_for_tls_window(not_after: str | None) -> tuple[str, str]:
     except ValueError:
         return "low", "Certificate expiration format unknown"
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(datetime.UTC)
     if expiry < now:
         return "high", "Certificate expired"
 


### PR DESCRIPTION
### Motivation
- Provide clearer, actionable output for users by surfacing scan stages, color-coded severities, and a concise final summary. 
- Add basic automated scoring so findings can be prioritized (ports, missing security headers, TLS expiry). 
- Make the tool friendlier in constrained environments by allowing `--no-nmap` to skip `nmap` when unavailable.

### Description
- Enhanced the terminal UX in the CLI with stage icons, explicit skip messaging, a findings table, and a compact final summary panel while preserving the existing `venomscan <target> [options]` shape (`venomscan/cli.py`).
- Added a severity engine implemented in `venomscan/severity.py` to score open ports, missing security headers, and TLS certificate expiry and to inject per-finding `severity` and `severity_reason` into reports.
- Persisted severity metadata to both outputs by updating the JSON writer and HTML template, and improved the HTML report template with severity badges, collapsible `details/summary` sections, better typography/spacing, and a top-level severity strip (`venomscan/reporting/templates/report.html.j2`, `venomscan/reporting/*.py`).
- Added a safe `--no-nmap` flag that produces a clear skipped `nmap` section instead of failing, and updated the CLI to honor it (`--no-nmap`).
- Expanded unit tests to cover the new severity functions and enrichment logic and updated docs to mention the new outputs and option (`tests/test_parsers.py`, `README.md`, `pyproject.toml`).
- Note: an attempt was made to capture before/after HTML screenshots in this environment, but the headless browser crashed so no artifacts were produced.

### Testing
- Ran `black .` and formatting was applied or verified as compliant.
- Ran `ruff check .` and lint checks passed.
- Ran `pytest -q` and all tests passed (unit tests exercise parsing/normalization and the new severity mappings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939f38a35c832f851006a4f90f1c0f)