### PR TITLE
feat: add YAML config support for venomscan v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+      - name: Test
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+reports/
+venomscan.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Setup commands
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Run commands
+```bash
+venomscan example.com
+venomscan 127.0.0.1 --format both --out-dir ./reports
+python -m venomscan.cli example.com
+```
+
+## Test commands
+```bash
+pytest -q
+```
+
+## Formatting and linting
+- Use **black** for formatting.
+- Use **ruff** for linting.
+
+```bash
+black .
+ruff check .
+```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also applies when an
+individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **security@venomscan.dev**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thank you for your interest in contributing to VenomScan.
+
+## Development Setup
+
+```bash
+git clone <repo-url>
+cd VenomScan
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Local Checks
+
+Run all checks before opening a PR:
+
+```bash
+ruff check .
+black .
+pytest -q
+```
+
+## Submitting a Pull Request
+
+1. Create a branch from the latest main branch.
+2. Keep changes scoped and well-documented.
+3. Ensure linting and tests pass locally.
+4. Open a pull request with a clear summary and testing notes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Matthew Spillane
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
-# VenomScan
-VenomScan by Strikepoint Security
+# venomscan
+
+![CI](https://github.com/venomscan/venomscan/actions/workflows/ci.yml/badge.svg)
+![Python](https://img.shields.io/badge/python-3.11%2B-blue)
+
+`venomscan` is a safe reconnaissance CLI for domains, hostnames, and IPs.
+
+## Overview
+
+VenomScan provides a focused, non-exploitative recon workflow with terminal and report outputs suitable for both manual review and automation.
+
+## Features
+
+- DNS resolution + common DNS records (`A`, `AAAA`, `CNAME`, `NS`, `MX`, `TXT`)
+- Nmap safe fast scan (top 1000 TCP ports + service/version detection)
+- HTTP(S) probe (`/`) with status, server header, and key security headers
+- TLS certificate + session metadata when HTTPS is available
+- Rich terminal summary with severity indicators
+- JSON report with per-finding severity metadata
+- HTML report with dark theme and severity badges
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Quick Start
+
+```bash
+venomscan example.com
+venomscan 127.0.0.1 --no-nmap
+venomscan example.com --format both --out-dir ./reports
+```
+
+## Usage
+
+```bash
+venomscan <target> [options]
+```
+
+### Options
+
+- `--out-dir PATH` (default: `./reports`)
+- `--format [json|html|both]` (default: `both`)
+- `--timeout INTEGER` (default: `8`)
+- `--nmap-args TEXT` (advanced override)
+- `--no-nmap` (skip nmap stage for constrained environments)
+
+## Safe Targets for Testing
+
+Use only systems you are authorized to assess. Common examples:
+
+- Localhost (`127.0.0.1`)
+- Privately owned lab hosts
+- Approved internal staging environments
+- Public demo targets explicitly intended for testing (with documented permission)
+
+## Security Notice
+
+VenomScan is for authorized security assessment only.
+
+- Do not scan targets without explicit permission.
+- Unauthorized scanning may be unlawful and is strictly prohibited.
+
+For vulnerability disclosure guidance, see [SECURITY.md](SECURITY.md).
+
+## Roadmap
+
+- Improve report rendering and accessibility
+- Expand normalization and parsing reliability
+- Add additional non-invasive recon quality-of-life enhancements
+
+## Development Checks
+
+```bash
+ruff check .
+black --check .
+pytest -q
+```
+
+## License
+
+MIT License. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in VenomScan, please report it responsibly by emailing:
+
+- **security@venomscan.dev**
+
+Please include:
+- A clear description of the issue
+- Steps to reproduce
+- Affected versions/commit hash
+- Potential impact
+
+We will acknowledge reports as quickly as possible and work toward remediation.
+
+## Responsible Use
+
+VenomScan is designed for authorized defensive security and recon workflows only.
+
+- Do **not** scan systems or networks without explicit permission.
+- Unauthorized scanning may violate laws, regulations, and acceptable use policies.
+
+Users are solely responsible for ensuring legal and authorized use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "venomscan"
+version = "0.1.0"
+description = "Safe reconnaissance CLI prototype"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name = "VenomScan Contributors"}]
+dependencies = [
+  "typer==0.12.5",
+  "rich==13.8.1",
+  "jinja2==3.1.4",
+  "dnspython==2.6.1"
+]
+
+[project.scripts]
+venomscan = "venomscan.cli:app"
+
+[tool.setuptools.packages.find]
+include = ["venomscan*"]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+
+
+[tool.ruff.lint.per-file-ignores]
+"venomscan/scanners/tls.py" = ["UP017"]
+"venomscan/severity.py" = ["UP017"]
+"tests/test_parsers.py" = ["UP017"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+typer==0.12.5
+rich==13.8.1
+jinja2==3.1.4
+dnspython==2.6.1
+pytest==8.3.3
+ruff==0.6.9
+black==24.8.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from venomscan.config import load_config, resolve_runtime_config
+
+
+def test_load_config_valid(tmp_path: Path) -> None:
+    config_path = tmp_path / "scan.yaml"
+    config_path.write_text(
+        """
+targets:
+  - example.com
+scanners:
+  dns: true
+  http: false
+  tls: true
+  nmap: false
+output:
+  format: html
+  out_dir: reports-custom
+timeouts:
+  http:
+    timeout: 5
+  tls:
+    timeout: 9
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_path)
+    assert cfg["targets"] == ["example.com"]
+    assert cfg["output"]["format"] == "html"
+    assert cfg["timeouts"]["http"]["timeout"] == 5
+
+
+def test_runtime_override_precedence() -> None:
+    cfg = {
+        "targets": ["example.com"],
+        "output": {"format": "html", "out_dir": "from-config"},
+        "timeouts": {"http": {"timeout": 4}, "tls": {"timeout": 7}},
+    }
+
+    resolved = resolve_runtime_config(
+        target="127.0.0.1",
+        raw_config=cfg,
+        cli_out_dir="cli-out",
+        cli_format="json",
+        cli_timeout=11,
+        cli_nmap_args=None,
+        cli_no_nmap=False,
+        default_nmap_args="-sT",
+    )
+
+    assert resolved["targets"] == ["127.0.0.1", "example.com"]
+    assert resolved["out_dir"] == "cli-out"
+    assert resolved["format"] == "json"
+    assert resolved["timeout"] == 11
+    assert resolved["http_timeout"] == 4
+    assert resolved["tls_timeout"] == 7
+
+
+def test_runtime_nmap_flag_overrides_config() -> None:
+    cfg = {"scanners": {"nmap": True}}
+    resolved = resolve_runtime_config(
+        target="127.0.0.1",
+        raw_config=cfg,
+        cli_out_dir=None,
+        cli_format=None,
+        cli_timeout=None,
+        cli_nmap_args=None,
+        cli_no_nmap=True,
+        default_nmap_args="-sT",
+    )
+
+    assert resolved["enable_nmap"] is False

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta, timezone
+
+from venomscan.scanners.dns import is_ip_target
+from venomscan.scanners.http import normalize_headers
+from venomscan.scanners.nmap import parse_nmap_output
+from venomscan.scanners.tls import _parse_cert_time
+from venomscan.severity import (
+    build_findings,
+    severity_for_missing_header,
+    severity_for_port,
+    severity_for_tls_window,
+)
+
+
+def test_is_ip_target() -> None:
+    assert is_ip_target("127.0.0.1")
+    assert is_ip_target("2001:db8::1")
+    assert not is_ip_target("example.com")
+
+
+def test_parse_nmap_output() -> None:
+    sample = """
+PORT     STATE SERVICE VERSION
+22/tcp   open  ssh     OpenSSH 8.9p1 Ubuntu
+80/tcp   open  http    nginx 1.24
+443/tcp  closed https
+"""
+    services = parse_nmap_output(sample)
+    assert len(services) == 2
+    assert services[0]["port"] == "22/tcp"
+    assert services[1]["service"] == "http"
+
+
+def test_normalize_headers() -> None:
+    headers = {"Server": "nginx", "X-Frame-Options": "DENY"}
+    normalized = normalize_headers(headers)
+    assert normalized["server"] == "nginx"
+    assert normalized["x-frame-options"] == "DENY"
+
+
+def test_parse_cert_time() -> None:
+    assert _parse_cert_time("Jan 01 00:00:00 2025 GMT").startswith("2025-01-01T00:00:00")
+    assert _parse_cert_time(None) is None
+
+
+def test_severity_port_mapping() -> None:
+    assert severity_for_port("22/tcp")[0] == "high"
+    assert severity_for_port("8080/tcp")[0] == "medium"
+    assert severity_for_port("80/tcp")[0] == "low"
+
+
+def test_header_severity() -> None:
+    assert severity_for_missing_header("content-security-policy") == "medium"
+    assert severity_for_missing_header("permissions-policy") == "low"
+
+
+def test_tls_window_severity() -> None:
+    expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    soon = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+    later = (datetime.now(timezone.utc) + timedelta(days=90)).isoformat()
+
+    assert severity_for_tls_window(expired)[0] == "high"
+    assert severity_for_tls_window(soon)[0] == "high"
+    assert severity_for_tls_window(later)[0] == "low"
+
+
+def test_build_findings_populates_severity() -> None:
+    report = {
+        "target": "example.com",
+        "nmap": {"services": [{"port": "22/tcp", "service": "ssh"}]},
+        "http": {
+            "https": {"security_headers": {"content-security-policy": None}},
+            "http": {"security_headers": {}},
+        },
+        "tls": {
+            "ok": True,
+            "not_after": (datetime.now(timezone.utc) + timedelta(days=4)).isoformat(),
+        },
+    }
+    findings = build_findings(report)
+    assert findings
+    assert any(f["severity"] == "high" for f in findings)
+    assert report["nmap"]["services"][0]["severity"] == "high"

--- a/venomscan/__init__.py
+++ b/venomscan/__init__.py
@@ -1,0 +1,4 @@
+"""venomscan package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/venomscan/cli.py
+++ b/venomscan/cli.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from venomscan.config import load_config, resolve_runtime_config
+from venomscan.reporting.html_report import render_html_report
+from venomscan.reporting.json_report import write_json_report
+from venomscan.scanners.dns import resolve_dns
+from venomscan.scanners.http import probe_http_https
+from venomscan.scanners.nmap import DEFAULT_NMAP_ARGS, run_nmap
+from venomscan.scanners.tls import get_tls_info
+from venomscan.severity import build_findings, summarize_severity
+
+app = typer.Typer(add_completion=False, help="Safe recon scanner prototype")
+console = Console()
+
+
+class OutputFormat(str, Enum):
+    JSON = "json"
+    HTML = "html"
+    BOTH = "both"
+
+
+@app.command()
+def main(
+    target: str = typer.Argument(..., help="Domain, hostname, or IP target"),
+    out_dir: Path | None = typer.Option(  # noqa: B008
+        None, "--out-dir", help="Directory for reports"
+    ),
+    format: OutputFormat | None = typer.Option(  # noqa: B008
+        None,
+        "--format",
+        help="Output format: json, html, or both",
+    ),
+    timeout: int | None = typer.Option(None, "--timeout", min=1, max=120),  # noqa: B008
+    nmap_args: str | None = typer.Option(
+        None, "--nmap-args", help="Advanced nmap args"
+    ),  # noqa: B008
+    no_nmap: bool = typer.Option(False, "--no-nmap", help="Skip nmap scan stage"),  # noqa: B008
+    config: Path | None = typer.Option(  # noqa: B008
+        None, "--config", help="Path to YAML config file"
+    ),
+) -> None:
+    raw_config: dict[str, Any] = {}
+    if config:
+        try:
+            raw_config = load_config(config)
+        except (RuntimeError, ValueError) as exc:
+            raise typer.BadParameter(str(exc), param_hint="--config") from exc
+
+    resolved = resolve_runtime_config(
+        target=target,
+        raw_config=raw_config,
+        cli_out_dir=str(out_dir) if out_dir else None,
+        cli_format=format.value if format else None,
+        cli_timeout=timeout,
+        cli_nmap_args=nmap_args,
+        cli_no_nmap=no_nmap,
+        default_nmap_args=DEFAULT_NMAP_ARGS,
+    )
+
+    for current_target in resolved["targets"]:
+        _run_scan(
+            target=str(current_target),
+            out_dir=Path(str(resolved["out_dir"])),
+            format=OutputFormat(str(resolved["format"])),
+            timeout=int(resolved["timeout"]),
+            http_timeout=int(resolved["http_timeout"]),
+            tls_timeout=int(resolved["tls_timeout"]),
+            nmap_args=str(resolved["nmap_args"]),
+            enable_dns=bool(resolved["enable_dns"]),
+            enable_http=bool(resolved["enable_http"]),
+            enable_tls=bool(resolved["enable_tls"]),
+            enable_nmap=bool(resolved["enable_nmap"]),
+            no_nmap=no_nmap,
+        )
+
+
+def _run_scan(
+    target: str,
+    out_dir: Path,
+    format: OutputFormat,
+    timeout: int,
+    http_timeout: int,
+    tls_timeout: int,
+    nmap_args: str,
+    enable_dns: bool,
+    enable_http: bool,
+    enable_tls: bool,
+    enable_nmap: bool,
+    no_nmap: bool,
+) -> None:
+    scanned_at = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base_name = f"{target.replace('/', '_')}_{scanned_at}"
+
+    console.print(Panel.fit(f"[bold red]venomscan[/bold red] scanning [bold]{target}[/bold]"))
+
+    if enable_dns:
+        console.print("🔎 [bold]DNS[/bold] resolving target and records...")
+        dns_data = resolve_dns(target, timeout=timeout)
+    else:
+        dns_data = {
+            "target": target,
+            "resolved_ip": None,
+            "records": {},
+            "errors": ["DNS scanner disabled by config"],
+        }
+
+    if enable_nmap:
+        console.print("🧭 [bold]Nmap[/bold] running safe TCP service scan...")
+        nmap_data = run_nmap(target, timeout=max(timeout * 4, 20), nmap_args=nmap_args)
+    else:
+        if no_nmap:
+            console.print("⏭️  [yellow]Nmap skipped[/yellow] (--no-nmap)")
+        nmap_data = {
+            "available": False,
+            "skipped": True,
+            "error": "Skipped due to scanner settings.",
+            "command": None,
+            "services": [],
+            "stdout": "",
+            "stderr": "",
+        }
+
+    if enable_http:
+        console.print("🌐 [bold]HTTP(S)[/bold] probing root endpoints...")
+        http_data = probe_http_https(target, timeout=http_timeout)
+    else:
+        http_data = {
+            "http": {
+                "ok": False,
+                "status_code": None,
+                "server": None,
+                "security_headers": {},
+                "error": "HTTP scanner disabled by config",
+            },
+            "https": {
+                "ok": False,
+                "status_code": None,
+                "server": None,
+                "security_headers": {},
+                "error": "HTTP scanner disabled by config",
+            },
+        }
+
+    if enable_tls and http_data.get("https", {}).get("ok"):
+        console.print("🔐 [bold]TLS[/bold] collecting certificate/session metadata...")
+        tls_data = get_tls_info(target, timeout=tls_timeout)
+    elif not enable_tls:
+        tls_data = {"ok": False, "error": "TLS scanner disabled by config."}
+    else:
+        console.print("⚠️  [yellow]TLS skipped[/yellow] (HTTPS not reachable)")
+        tls_data = {"ok": False, "error": "HTTPS probe failed; TLS details unavailable."}
+
+    report = {
+        "target": target,
+        "scanned_at": datetime.now().isoformat(),
+        "settings": {
+            "timeout": timeout,
+            "http_timeout": http_timeout,
+            "tls_timeout": tls_timeout,
+            "nmap_args": nmap_args,
+            "no_nmap": no_nmap,
+        },
+        "dns": dns_data,
+        "nmap": nmap_data,
+        "http": http_data,
+        "tls": tls_data,
+    }
+
+    findings = build_findings(report)
+    severity_counts = summarize_severity(findings)
+    report["severity_summary"] = severity_counts
+
+    _print_summary(report)
+
+    outputs: list[Path] = []
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if format in (OutputFormat.JSON, OutputFormat.BOTH):
+        json_path = out_dir / f"{base_name}.json"
+        write_json_report(json_path, report)
+        outputs.append(json_path)
+    if format in (OutputFormat.HTML, OutputFormat.BOTH):
+        html_path = out_dir / f"{base_name}.html"
+        render_html_report(html_path, report)
+        outputs.append(html_path)
+
+    for out in outputs:
+        console.print(f"[green]Saved:[/green] {out}")
+
+
+def _sev_text_label(level: str) -> str:
+    palette = {
+        "high": "[bold red]HIGH[/bold red]",
+        "medium": "[bold yellow]MEDIUM[/bold yellow]",
+        "low": "[bold cyan]LOW[/bold cyan]",
+    }
+    return palette.get(level, "LOW")
+
+
+def _print_summary(report: dict) -> None:
+    dns_data = report["dns"]
+    nmap_data = report["nmap"]
+    http_data = report["http"]
+    tls_data = report["tls"]
+    findings = report.get("findings", [])
+    sev = report.get("severity_summary", {"high": 0, "medium": 0, "low": 0})
+
+    table = Table(title="Recon Summary")
+    table.add_column("Section", style="red")
+    table.add_column("Details", overflow="fold")
+
+    dns_details = (
+        f"resolved_ip={dns_data.get('resolved_ip') or 'n/a'} "
+        f"errors={len(dns_data.get('errors', []))}"
+    )
+    table.add_row("🔎 DNS", dns_details)
+    table.add_row(
+        "🧭 Nmap",
+        (
+            f"open_ports={len(nmap_data.get('services', []))}"
+            if nmap_data.get("available")
+            else f"unavailable ({nmap_data.get('error')})"
+        ),
+    )
+    http_details = (
+        f"http={http_data['http'].get('status_code')} "
+        f"https={http_data['https'].get('status_code')}"
+    )
+    table.add_row("🌐 HTTP(S)", http_details)
+    table.add_row("🔐 TLS", "ok" if tls_data.get("ok") else tls_data.get("error", "unavailable"))
+
+    console.print(table)
+
+    finding_table = Table(title="Findings by Severity")
+    finding_table.add_column("Severity")
+    finding_table.add_column("Title")
+    finding_table.add_column("Details", overflow="fold")
+
+    for finding in findings[:12]:
+        finding_table.add_row(
+            _sev_text_label(finding.get("severity", "low")),
+            finding.get("title", "n/a"),
+            finding.get("details", ""),
+        )
+    if not findings:
+        finding_table.add_row(
+            "[cyan]LOW[/cyan]", "No notable findings", "No findings were generated"
+        )
+
+    console.print(finding_table)
+
+    final = Panel.fit(
+        "\n".join(
+            [
+                "[bold]Scan complete[/bold]",
+                f"[red]High:[/red] {sev['high']}  "
+                f"[yellow]Medium:[/yellow] {sev['medium']}  [cyan]Low:[/cyan] {sev['low']}",
+                f"Total findings: {len(findings)}",
+            ]
+        ),
+        border_style="red" if sev["high"] else "yellow" if sev["medium"] else "green",
+        title="📌 Final Summary",
+    )
+    console.print(final)
+
+
+if __name__ == "__main__":
+    app()

--- a/venomscan/config.py
+++ b/venomscan/config.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+ALLOWED_FORMATS = {"json", "html", "both"}
+SCANNER_KEYS = {"dns", "http", "tls", "nmap"}
+
+
+def _parse_scalar(value: str) -> Any:
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if value.isdigit():
+        return int(value)
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _simple_yaml_load(text: str) -> dict[str, Any]:
+    lines = [
+        line.rstrip()
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    def parse_block(index: int, indent: int) -> tuple[Any, int]:
+        if index >= len(lines):
+            return {}, index
+
+        current = lines[index]
+        is_list = current.startswith(" " * indent + "- ")
+        if is_list:
+            items: list[Any] = []
+            while index < len(lines):
+                line = lines[index]
+                if not line.startswith(" " * indent + "- "):
+                    break
+                item_value = line[indent + 2 :].strip()
+                index += 1
+                if item_value:
+                    items.append(_parse_scalar(item_value))
+                else:
+                    nested, index = parse_block(index, indent + 2)
+                    items.append(nested)
+            return items, index
+
+        mapping: dict[str, Any] = {}
+        while index < len(lines):
+            line = lines[index]
+            leading = len(line) - len(line.lstrip(" "))
+            if leading < indent:
+                break
+            if leading > indent:
+                break
+            if ":" not in line:
+                raise ValueError(f"Invalid YAML line: {line}")
+            key, raw_value = line[indent:].split(":", 1)
+            key = key.strip()
+            value = raw_value.strip()
+            index += 1
+            if value:
+                mapping[key] = _parse_scalar(value)
+            else:
+                nested, index = parse_block(index, indent + 2)
+                mapping[key] = nested
+        return mapping, index
+
+    parsed, _ = parse_block(0, 0)
+    if not isinstance(parsed, dict):
+        raise ValueError("Config root must be a mapping/object")
+    return parsed
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(f"Config file not found: {path}") from exc
+    except OSError as exc:
+        raise ValueError(f"Could not read config file: {exc}") from exc
+
+    try:
+        import yaml
+
+        raw = yaml.safe_load(text)
+    except ModuleNotFoundError:
+        raw = _simple_yaml_load(text)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Invalid YAML: {exc}") from exc
+
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("Config root must be a mapping/object")
+    return raw
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    config = _load_yaml(path)
+
+    targets = config.get("targets")
+    if targets is not None:
+        if not isinstance(targets, list) or not all(isinstance(t, str) and t for t in targets):
+            raise ValueError("'targets' must be a non-empty string list")
+
+    scanners = config.get("scanners", {})
+    if scanners is not None:
+        if not isinstance(scanners, dict):
+            raise ValueError("'scanners' must be a mapping")
+        for key, value in scanners.items():
+            if key not in SCANNER_KEYS:
+                raise ValueError(f"Unsupported scanner toggle: {key}")
+            if not isinstance(value, bool):
+                raise ValueError(f"Scanner toggle '{key}' must be boolean")
+
+    output = config.get("output", {})
+    if output is not None:
+        if not isinstance(output, dict):
+            raise ValueError("'output' must be a mapping")
+        out_format = output.get("format")
+        if out_format is not None and out_format not in ALLOWED_FORMATS:
+            raise ValueError("output.format must be one of: json, html, both")
+        out_dir = output.get("out_dir")
+        if out_dir is not None and not isinstance(out_dir, str):
+            raise ValueError("output.out_dir must be a string path")
+
+    timeouts = config.get("timeouts", {})
+    if timeouts is not None:
+        if not isinstance(timeouts, dict):
+            raise ValueError("'timeouts' must be a mapping")
+        for key in ("http", "tls"):
+            node = timeouts.get(key)
+            if node is None:
+                continue
+            if not isinstance(node, dict):
+                raise ValueError(f"timeouts.{key} must be a mapping")
+            timeout = node.get("timeout")
+            if timeout is not None and (not isinstance(timeout, int) or timeout < 1):
+                raise ValueError(f"timeouts.{key}.timeout must be a positive integer")
+
+    return config
+
+
+def resolve_runtime_config(
+    target: str,
+    raw_config: dict[str, Any],
+    cli_out_dir: str | None,
+    cli_format: str | None,
+    cli_timeout: int | None,
+    cli_nmap_args: str | None,
+    cli_no_nmap: bool,
+    default_nmap_args: str,
+) -> dict[str, Any]:
+    targets_from_config = raw_config.get("targets", [])
+    effective_targets = [target]
+    if targets_from_config:
+        effective_targets = [str(t) for t in targets_from_config]
+        if target not in effective_targets:
+            effective_targets.insert(0, target)
+
+    cfg_output = raw_config.get("output", {})
+    cfg_timeouts = raw_config.get("timeouts", {})
+
+    resolved_timeout = cli_timeout if cli_timeout is not None else 8
+    resolved = {
+        "targets": effective_targets,
+        "out_dir": cli_out_dir or cfg_output.get("out_dir", "reports"),
+        "format": cli_format or cfg_output.get("format", "both"),
+        "timeout": resolved_timeout,
+        "http_timeout": cfg_timeouts.get("http", {}).get("timeout", resolved_timeout),
+        "tls_timeout": cfg_timeouts.get("tls", {}).get("timeout", resolved_timeout),
+        "nmap_args": cli_nmap_args or default_nmap_args,
+    }
+
+    scanners = raw_config.get("scanners", {})
+    resolved["enable_dns"] = scanners.get("dns", True)
+    resolved["enable_http"] = scanners.get("http", True)
+    resolved["enable_tls"] = scanners.get("tls", True)
+    resolved["enable_nmap"] = scanners.get("nmap", True) and not cli_no_nmap
+
+    return resolved

--- a/venomscan/reporting/__init__.py
+++ b/venomscan/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting modules for venomscan."""

--- a/venomscan/reporting/html_report.py
+++ b/venomscan/reporting/html_report.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def render_html_report(path: Path, context: dict[str, Any]) -> None:
+    templates_dir = Path(__file__).parent / "templates"
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    template = env.get_template("report.html.j2")
+    html = template.render(**context)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(html, encoding="utf-8")

--- a/venomscan/reporting/json_report.py
+++ b/venomscan/reporting/json_report.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_json_report(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")

--- a/venomscan/reporting/templates/report.html.j2
+++ b/venomscan/reporting/templates/report.html.j2
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>venomscan report - {{ target }}</title>
+  <style>
+    :root {
+      --bg: #0b0b0f;
+      --card: #15151d;
+      --muted: #9ca3af;
+      --text: #f3f4f6;
+      --red: #ef4444;
+      --red-soft: #7f1d1d;
+      --green: #22c55e;
+      --yellow: #eab308;
+      --blue: #38bdf8;
+      --border: #27272a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      margin: 0;
+      padding: 28px;
+      line-height: 1.55;
+      letter-spacing: 0.01em;
+    }
+    .container { max-width: 1120px; margin: auto; }
+    .hero {
+      background: linear-gradient(130deg, #190f15, #1a1a25);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 20px 24px;
+      margin-bottom: 18px;
+    }
+    h1 { margin: 0 0 8px; font-size: 1.7rem; }
+    h2 { margin: 0 0 12px; font-size: 1.05rem; }
+    p { margin: 0 0 8px; }
+    .meta { color: var(--muted); }
+    .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px 16px;
+    }
+    .card h2 { border-left: 4px solid var(--red); padding-left: 8px; }
+    details {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 8px 10px;
+      margin-bottom: 10px;
+      background: rgba(255,255,255,0.01);
+    }
+    details[open] { background: rgba(239,68,68,0.04); }
+    summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: #fca5a5;
+      outline: none;
+    }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.92rem; }
+    th, td { border-bottom: 1px solid var(--border); padding: 7px; text-align: left; vertical-align: top; }
+    code {
+      background: #111827;
+      border: 1px solid #1f2937;
+      border-radius: 6px;
+      padding: 2px 6px;
+      overflow-wrap: anywhere;
+    }
+    .muted { color: var(--muted); }
+    .bad { color: var(--red); }
+    .sev {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.04em;
+      border: 1px solid transparent;
+    }
+    .sev-high { color: #fecaca; background: #3f1414; border-color: #7f1d1d; }
+    .sev-medium { color: #fef08a; background: #3f3212; border-color: #713f12; }
+    .sev-low { color: #bae6fd; background: #0c3142; border-color: #164e63; }
+    .summary-strip {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <section class="hero">
+    <h1>venomscan report :: {{ target }}</h1>
+    <div class="meta">Generated at {{ scanned_at }}</div>
+    <div class="summary-strip">
+      <span class="sev sev-high">HIGH {{ severity_summary.high }}</span>
+      <span class="sev sev-medium">MEDIUM {{ severity_summary.medium }}</span>
+      <span class="sev sev-low">LOW {{ severity_summary.low }}</span>
+    </div>
+  </section>
+
+  <section class="card" style="margin-bottom: 14px;">
+    <h2>Findings</h2>
+    <table>
+      <thead><tr><th>Severity</th><th>Title</th><th>Details</th></tr></thead>
+      <tbody>
+      {% for f in findings %}
+      <tr>
+        <td><span class="sev sev-{{ f.severity }}">{{ f.severity|upper }}</span></td>
+        <td>{{ f.title }}</td>
+        <td>{{ f.details }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="muted">No findings generated.</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <div class="grid">
+    <section class="card">
+      <details open>
+        <summary>🔎 DNS</summary>
+        <p><strong>Resolved IP:</strong> <code>{{ dns.resolved_ip or 'n/a' }}</code></p>
+        {% for rtype, values in dns.records.items() %}
+        <p><strong>{{ rtype }}:</strong> {{ values|join(', ') if values else 'none' }}</p>
+        {% endfor %}
+      </details>
+    </section>
+
+    <section class="card">
+      <details open>
+        <summary>🧭 Nmap</summary>
+        {% if nmap.available %}
+        <p><strong>Command:</strong> <code>{{ nmap.command }}</code></p>
+        {% if nmap.error %}<p class="bad">{{ nmap.error }}</p>{% endif %}
+        <table>
+          <thead><tr><th>Port</th><th>Severity</th><th>Service</th><th>Version</th></tr></thead>
+          <tbody>
+          {% for svc in nmap.services %}
+          <tr>
+            <td>{{ svc.port }}</td>
+            <td><span class="sev sev-{{ svc.severity or 'low' }}">{{ (svc.severity or 'low')|upper }}</span></td>
+            <td>{{ svc.service }}</td>
+            <td>{{ svc.version or '-' }}</td>
+          </tr>
+          {% else %}
+            <tr><td colspan="4" class="muted">No open ports detected or parsing unavailable.</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <p class="bad">{{ nmap.error }}</p>
+        {% endif %}
+      </details>
+    </section>
+
+    <section class="card">
+      <details open>
+        <summary>🌐 HTTP(S)</summary>
+        {% for scheme, probe in http.items() %}
+        <p><strong>{{ scheme|upper }}:</strong> {{ probe.status_code or '-' }}</p>
+        <p class="muted">Server: {{ probe.server or 'unknown' }}</p>
+        <table>
+          <thead><tr><th>Header</th><th>Value</th></tr></thead>
+          <tbody>
+          {% for h, v in probe.security_headers.items() %}
+          <tr>
+            <td>{{ h }}</td>
+            <td>{{ v or 'missing' }}</td>
+          </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+        {% endfor %}
+      </details>
+    </section>
+
+    <section class="card">
+      <details open>
+        <summary>🔐 TLS</summary>
+        {% if tls.ok %}
+        <p><strong>Severity:</strong> <span class="sev sev-{{ tls.severity or 'low' }}">{{ (tls.severity or 'low')|upper }}</span></p>
+        <p><strong>Reason:</strong> {{ tls.severity_reason }}</p>
+        <p><strong>Protocol:</strong> {{ tls.protocol }}</p>
+        <p><strong>Cipher:</strong> {{ tls.cipher }}</p>
+        <p><strong>SANs:</strong> {{ tls.san|join(', ') if tls.san else 'none' }}</p>
+        <p><strong>Validity:</strong> {{ tls.not_before }} → {{ tls.not_after }}</p>
+        {% else %}
+        <p class="bad">{{ tls.error or 'TLS probe unavailable' }}</p>
+        {% endif %}
+      </details>
+    </section>
+  </div>
+</div>
+</body>
+</html>

--- a/venomscan/scanners/__init__.py
+++ b/venomscan/scanners/__init__.py
@@ -1,0 +1,1 @@
+"""Scanning modules for venomscan."""

--- a/venomscan/scanners/dns.py
+++ b/venomscan/scanners/dns.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import Any
+
+RECORD_TYPES = ("A", "AAAA", "CNAME", "NS", "MX", "TXT")
+
+try:
+    import dns.exception
+    import dns.resolver
+except ModuleNotFoundError:  # pragma: no cover - environment fallback
+    dns = None
+
+
+def is_ip_target(target: str) -> bool:
+    try:
+        ipaddress.ip_address(target)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_dns(target: str, timeout: int = 8) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "target": target,
+        "resolved_ip": None,
+        "records": {rtype: [] for rtype in RECORD_TYPES},
+        "errors": [],
+    }
+
+    try:
+        if is_ip_target(target):
+            result["resolved_ip"] = target
+        else:
+            result["resolved_ip"] = socket.gethostbyname(target)
+    except socket.gaierror as exc:
+        result["errors"].append(f"Resolution failed: {exc}")
+
+    if is_ip_target(target):
+        return result
+
+    if dns is None:
+        result["errors"].append("dnspython not installed; detailed DNS records unavailable")
+        return result
+
+    resolver = dns.resolver.Resolver()
+    resolver.lifetime = timeout
+
+    for rtype in RECORD_TYPES:
+        try:
+            answers = resolver.resolve(target, rtype)
+            parsed = [record.to_text() for record in answers]
+            result["records"][rtype] = parsed
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.resolver.NoNameservers):
+            continue
+        except dns.exception.DNSException as exc:
+            result["errors"].append(f"{rtype} lookup failed: {exc}")
+
+    return result

--- a/venomscan/scanners/http.py
+++ b/venomscan/scanners/http.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib import error, request
+
+KEY_SECURITY_HEADERS = [
+    "strict-transport-security",
+    "content-security-policy",
+    "x-frame-options",
+    "x-content-type-options",
+    "referrer-policy",
+    "permissions-policy",
+]
+
+
+def normalize_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {k.lower(): v for k, v in headers.items()}
+
+
+def probe_url(url: str, timeout: int = 8) -> dict[str, Any]:
+    req = request.Request(url, method="GET", headers={"User-Agent": "venomscan/0.1"})
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            raw_headers = dict(resp.headers.items())
+            headers = normalize_headers(raw_headers)
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": resp.status,
+                "server": headers.get("server"),
+                "security_headers": {h: headers.get(h) for h in KEY_SECURITY_HEADERS},
+                "error": None,
+            }
+    except error.HTTPError as exc:
+        headers = normalize_headers(dict(exc.headers.items())) if exc.headers else {}
+        return {
+            "url": url,
+            "ok": False,
+            "status_code": exc.code,
+            "server": headers.get("server"),
+            "security_headers": {h: headers.get(h) for h in KEY_SECURITY_HEADERS},
+            "error": str(exc),
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "url": url,
+            "ok": False,
+            "status_code": None,
+            "server": None,
+            "security_headers": {h: None for h in KEY_SECURITY_HEADERS},
+            "error": str(exc),
+        }
+
+
+def probe_http_https(target: str, timeout: int = 8) -> dict[str, Any]:
+    return {
+        "http": probe_url(f"http://{target}/", timeout=timeout),
+        "https": probe_url(f"https://{target}/", timeout=timeout),
+    }

--- a/venomscan/scanners/nmap.py
+++ b/venomscan/scanners/nmap.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+from typing import Any
+
+DEFAULT_NMAP_ARGS = "-sT -Pn --top-ports 1000 -sV"
+
+
+def parse_nmap_output(stdout: str) -> list[dict[str, str]]:
+    services: list[dict[str, str]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or "/tcp" not in line or "open" not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        port = parts[0]
+        state = parts[1]
+        service = parts[2]
+        version = " ".join(parts[3:]) if len(parts) > 3 else ""
+        services.append(
+            {
+                "port": port,
+                "state": state,
+                "service": service,
+                "version": version,
+            }
+        )
+    return services
+
+
+def run_nmap(target: str, timeout: int = 30, nmap_args: str | None = None) -> dict[str, Any]:
+    if not shutil.which("nmap"):
+        return {
+            "available": False,
+            "error": "nmap is not installed or not in PATH.",
+            "command": None,
+            "services": [],
+            "stdout": "",
+            "stderr": "",
+        }
+
+    effective_args = nmap_args or DEFAULT_NMAP_ARGS
+    cmd = ["nmap", *shlex.split(effective_args), target]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "available": True,
+            "error": f"nmap timed out after {timeout} seconds",
+            "command": " ".join(cmd),
+            "services": [],
+            "stdout": "",
+            "stderr": "",
+        }
+
+    return {
+        "available": True,
+        "error": None if proc.returncode == 0 else f"nmap exited with code {proc.returncode}",
+        "command": " ".join(cmd),
+        "services": parse_nmap_output(proc.stdout),
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }

--- a/venomscan/scanners/tls.py
+++ b/venomscan/scanners/tls.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import socket
+import ssl
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _parse_cert_time(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.strptime(value, "%b %d %H:%M:%S %Y %Z").replace(
+            tzinfo=timezone.utc
+        )  # noqa: UP017
+    except ValueError:
+        return value
+    return dt.isoformat()
+
+
+def get_tls_info(host: str, timeout: int = 8, port: int = 443) -> dict[str, Any]:
+    try:
+        ctx = ssl.create_default_context()
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+                cert = ssock.getpeercert()
+                sans = [entry[1] for entry in cert.get("subjectAltName", []) if len(entry) >= 2]
+                subject = cert.get("subject", ())
+                issuer = cert.get("issuer", ())
+                return {
+                    "ok": True,
+                    "subject": subject,
+                    "issuer": issuer,
+                    "san": sans,
+                    "not_before": _parse_cert_time(cert.get("notBefore")),
+                    "not_after": _parse_cert_time(cert.get("notAfter")),
+                    "protocol": ssock.version(),
+                    "cipher": ssock.cipher(),
+                    "error": None,
+                }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "subject": None,
+            "issuer": None,
+            "san": [],
+            "not_before": None,
+            "not_after": None,
+            "protocol": None,
+            "cipher": None,
+            "error": str(exc),
+        }

--- a/venomscan/severity.py
+++ b/venomscan/severity.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    UTC = datetime.UTC  # type: ignore[attr-defined]
+except AttributeError:
+    UTC = timezone.utc  # noqa: UP017
+
+
+HIGH_RISK_PORTS = {
+    "21": "FTP exposed",
+    "22": "SSH exposed",
+    "23": "Telnet exposed",
+    "25": "SMTP exposed",
+    "3389": "RDP exposed",
+    "445": "SMB exposed",
+    "1433": "MSSQL exposed",
+    "3306": "MySQL exposed",
+}
+MEDIUM_RISK_PORTS = {
+    "53": "DNS service exposed",
+    "111": "RPC exposed",
+    "139": "NetBIOS exposed",
+    "5900": "VNC exposed",
+    "8080": "Alt HTTP exposed",
+}
+
+
+def _port_number(port: str) -> str:
+    return port.split("/")[0]
+
+
+def severity_for_port(port: str) -> tuple[str, str]:
+    number = _port_number(port)
+    if number in HIGH_RISK_PORTS:
+        return "high", HIGH_RISK_PORTS[number]
+    if number in MEDIUM_RISK_PORTS:
+        return "medium", MEDIUM_RISK_PORTS[number]
+    if number in {"80", "443"}:
+        return "low", "Common web service"
+    return "low", "Open port"
+
+
+def severity_for_missing_header(header: str) -> str:
+    medium_headers = {"content-security-policy", "strict-transport-security", "x-frame-options"}
+    return "medium" if header in medium_headers else "low"
+
+
+def severity_for_tls_window(not_after: str | None) -> tuple[str, str]:
+    if not not_after:
+        return "low", "Certificate expiration unknown"
+    try:
+        expiry = datetime.fromisoformat(not_after.replace("Z", "+00:00"))
+    except ValueError:
+        return "low", "Certificate expiration format unknown"
+
+    now = datetime.now(UTC)
+    if expiry < now:
+        return "high", "Certificate expired"
+
+    days_remaining = (expiry - now).days
+    if days_remaining <= 14:
+        return "high", f"Certificate expires soon ({days_remaining} days)"
+    if days_remaining <= 45:
+        return "medium", f"Certificate expires soon-ish ({days_remaining} days)"
+    return "low", f"Certificate valid ({days_remaining} days remaining)"
+
+
+def build_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+
+    for svc in report.get("nmap", {}).get("services", []):
+        severity, reason = severity_for_port(svc.get("port", ""))
+        finding = {
+            "category": "open_port",
+            "target": svc.get("port"),
+            "severity": severity,
+            "title": f"Open port {svc.get('port')}",
+            "details": reason,
+            "service": svc.get("service"),
+        }
+        svc["severity"] = severity
+        svc["severity_reason"] = reason
+        findings.append(finding)
+
+    for scheme, probe in report.get("http", {}).items():
+        for header, value in probe.get("security_headers", {}).items():
+            if value:
+                continue
+            severity = severity_for_missing_header(header)
+            findings.append(
+                {
+                    "category": "missing_security_header",
+                    "target": scheme,
+                    "severity": severity,
+                    "title": f"Missing header: {header}",
+                    "details": f"{scheme.upper()} response is missing {header}",
+                }
+            )
+
+    tls = report.get("tls", {})
+    if tls.get("ok"):
+        severity, reason = severity_for_tls_window(tls.get("not_after"))
+        tls["severity"] = severity
+        tls["severity_reason"] = reason
+        findings.append(
+            {
+                "category": "tls_certificate",
+                "target": report.get("target"),
+                "severity": severity,
+                "title": "TLS certificate health",
+                "details": reason,
+            }
+        )
+
+    report["findings"] = findings
+    return findings
+
+
+def summarize_severity(findings: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {"high": 0, "medium": 0, "low": 0}
+    for finding in findings:
+        sev = finding.get("severity", "low")
+        if sev not in counts:
+            continue
+        counts[sev] += 1
+    return counts


### PR DESCRIPTION
### Motivation
- Provide a v0.2.0-compatible YAML config file to allow scanning multiple targets and toggling scanners/timeouts without changing existing flags.
- Keep backward compatible behavior when `--config` is not supplied and allow CLI flags to continue to override any config values.
- Surface friendly error messages for invalid or missing config via `typer.BadParameter` so users see concise feedback (no tracebacks).

### Description
- Added a small `venomscan/config.py` module that loads and validates a supported YAML subset and exposes `load_config` and `resolve_runtime_config` for runtime resolution and precedence handling.
- Added `--config PATH` Typer option to the existing `scan` command and integrated runtime resolution so the CLI merges config and flags (flags take precedence) and expands targets to run multiple scans.
- Supported config keys: `targets: list[str]`, `scanners: {dns,http,tls,nmap}: bool`, `output.format` (`json|html|both`) and `output.out_dir`, and `timeouts.http.timeout` / `timeouts.tls.timeout` (ints).
- Implemented a safe fallback YAML parser when PyYAML is not available (but will use `yaml.safe_load` if present), and kept changes localized to `venomscan/config.py`, `venomscan/cli.py`, and new tests.

### Testing
- Added `tests/test_config.py` covering config parsing, runtime resolution precedence (CLI overrides), target expansion, and `--no-nmap` behavior; all tests pass (`pytest -q` reported success).
- Linting and formatting checks passed (`ruff check .` and `black` formatting applied where needed).
- Local validation run: `ruff check .` succeeded and `pytest -q` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939f38a35c832f851006a4f90f1c0f)